### PR TITLE
primeserver gis-ops docker dependency

### DIFF
--- a/Ubuntu/18.04/Valhalla/Dockerfile
+++ b/Ubuntu/18.04/Valhalla/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM gisops/prime_server-nodejs:0.6.4-10.15.0
 MAINTAINER Julian Psotta <julian@gis-ops.com>
 
 # Set docker specific settings
@@ -25,7 +25,6 @@ RUN apt-get install -y cmake build-essential autoconf pkg-config
 RUN apt-get install -y wget curl ca-certificates gnupg2 git parallel
 
 # Prime server deps
-# libcurl4 and libcurl4-openssl-dev are installed in the prime server script directly to avoid path problems.
 RUN apt-get install -y libczmq-dev libzmq5
 
 # Valhalla deps
@@ -40,13 +39,10 @@ RUN mkdir /conf
 RUN mkdir /scripts
 
 # Copy scripts
-COPY build_prime_server.sh /foo
 COPY build_valhalla.sh /foo
 
 WORKDIR /foo
 
-# Build Prime Server
-RUN /bin/bash build_prime_server.sh
 
 # Build Valhalla
 RUN /bin/bash build_valhalla.sh

--- a/Ubuntu/18.04/Valhalla/docker-compose.yml
+++ b/Ubuntu/18.04/Valhalla/docker-compose.yml
@@ -12,9 +12,11 @@ services:
         tile_file: albania-latest.osm.pbf
         tile_url: https://download.geofabrik.de/europe/albania-latest.osm.pbf
         # Get correct bounding box from e.g. https://boundingbox.klokantech.com/
-        min_x: 0 # 18 # -> Albania | -180 -> World
-        min_y: 0 # 38 # -> Albania | -90  -> World
-        max_x: 0 # 22 # -> Albania |  180 -> World
-        max_y: 0 # 43 # -> Albania |  90  -> World
+        min_x: 11 # 18 # -> Albania | -180 -> World
+        min_y: 46 # 38 # -> Albania | -90  -> World
+        max_x: 14 # 22 # -> Albania |  180 -> World
+        max_y: 49 # 43 # -> Albania |  90  -> World
     ports:
       - "8002:8002"
+    volumes:
+      - "./valhalla_git:/foo/valhalla_git"


### PR DESCRIPTION
added prime server dependency from gis-ops dockerhub. no need to build it anymore :fireworks: 
