### PR TITLE
Edit readme and entrypoint

### DIFF
--- a/docker-hub-images/valhalla/Dockerfile
+++ b/docker-hub-images/valhalla/Dockerfile
@@ -57,3 +57,4 @@ COPY scripts/configure_valhalla.sh ${SCRIPTS_DIR}
 
 # Expose the necessary port
 EXPOSE 8002
+ENTRYPOINT ["/bin/bash", "/valhalla/scripts/run.sh"]

--- a/docker-hub-images/valhalla/README.md
+++ b/docker-hub-images/valhalla/README.md
@@ -1,28 +1,85 @@
-Base dockerfile for the gis-ops dockerhub valhalla image
+# Valhalla Docker image by GIS • OPS
 
-Build command for a specific version:
+A hyper-flexible Docker image for the excellent [Valhalla](https://github.com/valhalla/valhalla) routing framework.
+
 ```bash
-docker build --build-arg version=xxx -t gisops/valhalla:xxx .
+docker run -dt --name valhalla_gis-ops -v $PWD/custom_files:/custom_files gisops/valhalla:latest
 ```
 
-Build command for the latest version:
-```bash
-docker build -t gisops/valhalla:latest .
-```
+This image aims at being user-friendly and most efficient with your time and resources. Once built, you can easily change Valhalla's configuration, the underlying OSM data graphs are built from, accompanying data (like Admin Areas, elevation tiles) or even pre-built graph tiles. Upon `docker restart <container>` those changes are taken into account via **hashed files**, and, if necessary, new graph tiles will be built automatically.
 
+## Features
 
-# Description   
--   An easy graph switch through remapping different volumes.
+-   Easily switch graphs by mapping different volumes to containers.
 -   Stores all relevant data (Admin areas, elevation, TimeZone data, tiles) in the mapped volume.
--   Load and built from multiple urls pointing to valid pbf files.
--   Load local data through an easy volume mapping.
--   Supports auto rebuild on local file changes through hash mapping.
+-   Load and built from **multiple URLs** pointing to valid pbf files.
+-   Load local data through volume mapping.
+-   **Supports auto rebuild** on volume file changes through hash mapping.
 
-# Example docker-compose
+## Container recipes
+
+For the following instructions to work, you'll need to have the image locally available already, either from [Docker Hub](https://hub.docker.com/repository/docker/gisops/valhalla) or from local:
+
+```bash
+docker build -t gisops/valhalla .
+#or
+docker pull gisops/valhalla:latest
+```
+
+Then start a background container from that image:
+
+```bash
+docker run -dt -v $PWD/custom_files:/custom_files --name valhalla_1 valhalla
+```
+
+The important part here is, that you map a volume from your host machine to **`/custom_files`**. The container will dump all relevant Valhalla files to that directory.
+
+At this point Valhalla is running, but there is no graph tiles yet. Follow the steps below to customize your Valhalla instance in a heartbeat.
+
+> Note, alternatively you could create `custom_files` on your host before starting the container with all necessary files you want to be respected, e.g. the OSM PBF files.
+
+#### Build Valhalla with arbitrary OSM data
+
+Just dump **single or multiple** OSM PBF files to your mapped `custom_files` directory, restart the container and Valhalla will start building the graphs:
+
+```bash
+cd custom_files
+# Download Andorra & Faroe Islands
+wget http://download.geofabrik.de/europe/faroe-islands-latest.osm.pbf http://download.geofabrik.de/europe/andorra-latest.osm.pbf
+docker restart valhalla_1
+```
+
+If you every change the PBF files by either adding new ones or deleting any, Valhalla will build new tiles on the next restart.
+
+#### Customize Valhalla configuration
+
+If you need to customize Valhalla's configuration to e.g. increase the allowed maximum distance for the `/route` POST endpoint, just edit `custom_files/valhalla.json` and restart the container. It won't rebuild the tiles in this case.
+
+#### Run Valhalla with pre-built tiles
+
+In the case where you have a pre-built `tiles.tar` package from another Valhalla instance, you can also dump that to `custom_files/` and they're loaded upon container restart.
+
+## Environment variables
+
+This image respects the following custom environment variables to be passed during container startup:
+
+- `tile_urls`: Add as many (space-separated) URLs as you like, e.g. https://download.geofabrik.de/europe/andorra-latest.osm.pbf http://download.geofabrik.de/europe/faroe-islands-latest.osm.pbf
+- `min_x`: Minimum longitude for elevation tiles, in decimal WGS84, e.g. 18.5
+- `min_y`: Minimum latitude for elevation tiles, in decimal WGS84, e.g. 18.5
+- `max_x`: Maximum longitude for elevation tiles, in decimal WGS84, e.g. 18.5
+- `max_y`: Maximum latitude for elevation tiles, in decimal WGS84, e.g. 18.5
+- `use_tiles_only`: ??
+- `force_rebuild`: Force a complete rebuild of the PBF files. Only skipping elevation.
+- `force_rebuild_elevation`: Force a rebuild of the elevation data as well.
+- `build_elevation`: General switch to build with elevation support.
+- `build_admins`: General switch to build with admin data support.
+- `build_time_zones`: General switch to build with time zone support.
+
+## Example `docker-compose.yml`
 
 - Create a `docker-compose.yml` and paste the content below.
 - Now create a `custom_files` folder in the same directory to be able to mount it as a volume.
-- Add your desired pbf extracts in the folder or specify URLs in the `docker-compose.yml`.
+- Add your desired PBF extracts in the folder or specify URLs in the `docker-compose.yml`.
 - Local files are always preferred!
 - If you change your local files and want to rebuild, just restart the docker container.
 ```docker
@@ -30,7 +87,6 @@ version: '3.0'
 services:
   valhalla:
     image: gisops/valhalla:latest
-    entrypoint: "/valhalla/scripts/run.sh"
     ports:
       - "8002:8002"
     volumes:
@@ -48,9 +104,5 @@ services:
       - build_admins=True
       - build_time_zones=True
 ```
-- tile_urls: Add as many URLs as you like.
-- force_rebuild: Force a complete rebuild of the pbf files. Only skipping elevation.
-- force_rebuild_elevation: Force a rebuild of the elevation data as well.
-- build_elevation: General switch to build with elevation support.
-- build_admins: General switch to build with admin data support.
-- build_time_zones: General switch to build with time zone support.
+
+See [Environment variables](#environment-variables) for an explanation of the environment variables.

--- a/docker-hub-images/valhalla/docker-compose.yml.template
+++ b/docker-hub-images/valhalla/docker-compose.yml.template
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   valhalla:
-    image: gisops/valhalla:3.0.8
+    image: gisops/valhalla:latest
     ports:
       - "8002:8002"
     volumes:

--- a/docker-hub-images/valhalla/docker-compose.yml.template
+++ b/docker-hub-images/valhalla/docker-compose.yml.template
@@ -2,7 +2,6 @@ version: '3.0'
 services:
   valhalla:
     image: gisops/valhalla:3.0.8
-    entrypoint: "/valhalla/scripts/run.sh"
     ports:
       - "8002:8002"
     volumes:


### PR DESCRIPTION
Aside from README, this move the entrypoint instruction to the Dockerfile, otherwise `docker run -dt gisops/valhalla` doesn't know what to do with the image. In `docker-compose.yml` or the (equivalent) command line arg for `docker run --entrypoint` it's only for overriding the Dockerfile's default.